### PR TITLE
Implement the compare operator properly

### DIFF
--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -50,6 +50,21 @@ std::size_t Agent::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Agent::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    return true;
+}
+
 void Agent::accept( Visitor& visitor )
 {
     visitor.visit( *this );

--- a/src/Agent.h
+++ b/src/Agent.h
@@ -43,6 +43,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override;
 
         static inline Value::ID classid( void )

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -75,6 +75,22 @@ std::size_t Block::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Block::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Block& >( rhs );
+    return ( this->name() == other.name() );
+}
+
 u1 Block::classof( Value const* obj )
 {
     return obj->id() == classid() or ExecutionSemanticsBlock::classof( obj )

--- a/src/Block.h
+++ b/src/Block.h
@@ -58,6 +58,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         static inline Value::ID classid( void )
         {
             return Value::BLOCK;

--- a/src/Builtin.cpp
+++ b/src/Builtin.cpp
@@ -50,6 +50,22 @@ std::size_t Builtin::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Builtin::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Builtin& >( rhs );
+    return ( this->name() == other.name() );
+}
+
 void Builtin::accept( Visitor& visitor )
 {
     visitor.visit( *this );

--- a/src/Builtin.h
+++ b/src/Builtin.h
@@ -41,6 +41,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override final;
 
         static inline Value::ID classid( void )

--- a/src/Constant.cpp
+++ b/src/Constant.cpp
@@ -277,6 +277,69 @@ std::size_t Constant::hash( void ) const
     return 0;
 }
 
+u1 Constant::operator==( const Value& rhs ) const
+{
+    switch( id() )
+    {
+        case Value::VOID_CONSTANT:
+        {
+            return static_cast< const VoidConstant* >( this )->operator==(
+                rhs );
+        }
+        case Value::BOOLEAN_CONSTANT:
+        {
+            return static_cast< const BooleanConstant* >( this )->operator==(
+                rhs );
+        }
+        case Value::INTEGER_CONSTANT:
+        {
+            return static_cast< const IntegerConstant* >( this )->operator==(
+                rhs );
+        }
+        case Value::BIT_CONSTANT:
+        {
+            return static_cast< const BitConstant* >( this )->operator==( rhs );
+        }
+        case Value::STRING_CONSTANT:
+        {
+            return static_cast< const StringConstant* >( this )->operator==(
+                rhs );
+        }
+        case Value::FLOATING_CONSTANT:
+        {
+            return static_cast< const FloatingConstant* >( this )->operator==(
+                rhs );
+        }
+        case Value::RATIONAL_CONSTANT:
+        {
+            return static_cast< const RationalConstant* >( this )->operator==(
+                rhs );
+        }
+        case Value::ENUMERATION_CONSTANT:
+        {
+            return static_cast< const EnumerationConstant* >( this )->
+            operator==( rhs );
+        }
+        case Value::RANGE_CONSTANT:
+        {
+            return static_cast< const RangeConstant* >( this )->operator==(
+                rhs );
+        }
+        case Value::RULE_REFERENCE_CONSTANT:
+        {
+            return static_cast< const RuleReferenceConstant* >( this )->
+            operator==( rhs );
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    assert( !" invalid constant to dispatch 'operator==' found! " );
+    return false;
+}
+
 u1 Constant::classof( Value const* obj )
 {
     return obj->id() == classid() or VoidConstant::classof( obj )
@@ -398,6 +461,22 @@ std::size_t VoidConstant::hash( void ) const
     return h;
 }
 
+u1 VoidConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const VoidConstant& >( rhs );
+    return ( this->defined() == other.defined() );
+}
+
 u1 VoidConstant::classof( Value const* obj )
 {
     return obj->id() == classid();
@@ -442,6 +521,23 @@ std::size_t BooleanConstant::hash( void ) const
 {
     const auto h = ( ( (std::size_t)classid() ) << 1 ) | defined();
     return libstdhl::Hash::combine( h, value() );
+}
+
+u1 BooleanConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const BooleanConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
 }
 
 u1 BooleanConstant::classof( Value const* obj )
@@ -522,6 +618,23 @@ std::size_t IntegerConstant::hash( void ) const
 {
     const auto h = ( ( (std::size_t)classid() ) << 1 ) | defined();
     return libstdhl::Hash::combine( h, libstdhl::Hash::value( value() ) );
+}
+
+u1 IntegerConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const IntegerConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
 }
 
 u1 IntegerConstant::classof( Value const* obj )
@@ -625,6 +738,23 @@ std::size_t BitConstant::hash( void ) const
     return libstdhl::Hash::combine( h, libstdhl::Hash::value( value() ) );
 }
 
+u1 BitConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const BitConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
+}
+
 u1 BitConstant::classof( Value const* obj )
 {
     return obj->id() == classid();
@@ -670,6 +800,23 @@ std::size_t StringConstant::hash( void ) const
 {
     const auto h = ( ( (std::size_t)classid() ) << 1 ) | defined();
     return libstdhl::Hash::combine( h, libstdhl::Hash::value( value() ) );
+}
+
+u1 StringConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const StringConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
 }
 
 u1 StringConstant::classof( Value const* obj )
@@ -729,6 +876,23 @@ std::size_t FloatingConstant::hash( void ) const
     return libstdhl::Hash::combine( h, libstdhl::Hash::value( value() ) );
 }
 
+u1 FloatingConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const FloatingConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
+}
+
 u1 FloatingConstant::classof( Value const* obj )
 {
     return obj->id() == classid();
@@ -779,6 +943,23 @@ std::size_t RationalConstant::hash( void ) const
 {
     const auto h = ( ( (std::size_t)classid() ) << 1 ) | defined();
     return libstdhl::Hash::combine( h, libstdhl::Hash::value( value() ) );
+}
+
+u1 RationalConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const RationalConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
 }
 
 u1 RationalConstant::classof( Value const* obj )
@@ -840,6 +1021,23 @@ std::size_t EnumerationConstant::hash( void ) const
 {
     const auto h = ( ( (std::size_t)classid() ) << 1 ) | defined();
     return libstdhl::Hash::combine( h, libstdhl::Hash::value( value() ) );
+}
+
+u1 EnumerationConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const EnumerationConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
 }
 
 u1 EnumerationConstant::classof( Value const* obj )
@@ -910,6 +1108,23 @@ std::size_t RangeConstant::hash( void ) const
     return libstdhl::Hash::combine( h, value()->hash() );
 }
 
+u1 RangeConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const RangeConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
+}
+
 u1 RangeConstant::classof( Value const* obj )
 {
     return obj->id() == classid();
@@ -955,6 +1170,23 @@ std::size_t RuleReferenceConstant::hash( void ) const
     return libstdhl::Hash::combine( h, value()->hash() );
 }
 
+u1 RuleReferenceConstant::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const RuleReferenceConstant& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->value() == other.value() );
+}
+
 u1 RuleReferenceConstant::classof( Value const* obj )
 {
     return obj->id() == classid();
@@ -983,6 +1215,23 @@ std::size_t Identifier::hash( void ) const
 {
     const auto h = ( ( (std::size_t)classid() ) << 1 ) | defined();
     return libstdhl::Hash::combine( h, libstdhl::Hash::value( name() ) );
+}
+
+u1 Identifier::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Identifier& >( rhs );
+    return ( this->defined() == other.defined() )
+           and ( this->name() == other.name() );
 }
 
 u1 Identifier::classof( Value const* obj )

--- a/src/Constant.h
+++ b/src/Constant.h
@@ -70,6 +70,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         static inline Value::ID classid( void )
         {
             return Value::CONSTANT;
@@ -112,6 +114,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         static inline Value::ID classid( void )
         {
             return Value::VOID_CONSTANT;
@@ -139,6 +143,8 @@ namespace libcasm_ir
         void accept( Visitor& visitor ) override;
 
         std::size_t hash( void ) const override;
+
+        u1 operator==( const Value& rhs ) const override;
 
         static inline Value::ID classid( void )
         {
@@ -176,6 +182,8 @@ namespace libcasm_ir
         void accept( Visitor& visitor ) override;
 
         std::size_t hash( void ) const override;
+
+        u1 operator==( const Value& rhs ) const override;
 
         static inline Value::ID classid( void )
         {
@@ -224,6 +232,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         static inline Value::ID classid( void )
         {
             return Value::BIT_CONSTANT;
@@ -251,6 +261,8 @@ namespace libcasm_ir
         void accept( Visitor& visitor ) override;
 
         std::size_t hash( void ) const override;
+
+        u1 operator==( const Value& rhs ) const override;
 
         static inline Value::ID classid( void )
         {
@@ -283,6 +295,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         static inline Value::ID classid( void )
         {
             return Value::FLOATING_CONSTANT;
@@ -312,6 +326,8 @@ namespace libcasm_ir
         void accept( Visitor& visitor ) override;
 
         std::size_t hash( void ) const override;
+
+        u1 operator==( const Value& rhs ) const override;
 
         static inline Value::ID classid( void )
         {
@@ -349,6 +365,8 @@ namespace libcasm_ir
         void accept( Visitor& visitor ) override;
 
         std::size_t hash( void ) const override;
+
+        u1 operator==( const Value& rhs ) const override;
 
         static inline Value::ID classid( void )
         {
@@ -388,6 +406,8 @@ namespace libcasm_ir
         Constant choose( void ) const;
 
         std::size_t hash( void ) const override;
+
+        u1 operator==( const Value& rhs ) const override;
 
         static inline Value::ID classid( void )
         {
@@ -440,6 +460,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         static inline Value::ID classid( void )
         {
             return Value::RULE_REFERENCE_CONSTANT;
@@ -490,6 +512,8 @@ namespace libcasm_ir
         void accept( Visitor& visitor ) override;
 
         std::size_t hash( void ) const override;
+
+        u1 operator==( const Value& rhs ) const override;
 
         static inline Value::ID classid( void )
         {

--- a/src/Derived.cpp
+++ b/src/Derived.cpp
@@ -54,6 +54,22 @@ std::size_t Derived::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Derived::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Derived& >( rhs );
+    return ( this->name() == other.name() );
+}
+
 void Derived::accept( Visitor& visitor )
 {
     visitor.visit( *this );

--- a/src/Derived.h
+++ b/src/Derived.h
@@ -47,6 +47,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override;
 
         static inline Value::ID classid( void )

--- a/src/Enumeration.cpp
+++ b/src/Enumeration.cpp
@@ -99,6 +99,22 @@ std::size_t Enumeration::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Enumeration::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Enumeration& >( rhs );
+    return ( this->name() == other.name() );
+}
+
 void Enumeration::accept( Visitor& visitor )
 {
     visitor.visit( *this );

--- a/src/Enumeration.h
+++ b/src/Enumeration.h
@@ -52,6 +52,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override;
 
         static inline Value::ID classid( void )

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -46,6 +46,22 @@ std::size_t Function::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Function::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Function& >( rhs );
+    return ( this->name() == other.name() );
+}
+
 u1 Function::classof( Value const* obj )
 {
     return obj->id() == classid();

--- a/src/Function.h
+++ b/src/Function.h
@@ -39,6 +39,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override;
 
         static inline Value::ID classid( void )

--- a/src/Instruction.cpp
+++ b/src/Instruction.cpp
@@ -166,6 +166,21 @@ std::size_t Instruction::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Instruction::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    return true;
+}
+
 u1 Instruction::classof( Value const* obj )
 {
     return obj->id() == classid() or SkipInstruction::classof( obj )

--- a/src/Instruction.h
+++ b/src/Instruction.h
@@ -80,6 +80,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         static inline Value::ID classid( void )
         {
             return Value::INSTRUCTION;

--- a/src/Range.cpp
+++ b/src/Range.cpp
@@ -69,6 +69,23 @@ std::size_t Range::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Range::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Range& >( rhs );
+    return ( *this->from() == *other.from() )
+           and ( *this->to() == *other.to() );
+}
+
 void Range::accept( Visitor& visitor )
 {
     visitor.visit( *this );

--- a/src/Range.h
+++ b/src/Range.h
@@ -49,6 +49,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override;
 
         static inline Value::ID classid( void )

--- a/src/Rule.cpp
+++ b/src/Rule.cpp
@@ -72,6 +72,22 @@ std::size_t Rule::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Rule::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Rule& >( rhs );
+    return ( this->name() == other.name() );
+}
+
 void Rule::accept( Visitor& visitor )
 {
     visitor.visit( *this );

--- a/src/Rule.h
+++ b/src/Rule.h
@@ -47,6 +47,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override final;
 
         static inline Value::ID classid( void )

--- a/src/Specification.cpp
+++ b/src/Specification.cpp
@@ -108,6 +108,22 @@ std::size_t Specification::hash( void ) const
         classid(), std::hash< std::string >()( name() ) );
 }
 
+u1 Specification::operator==( const Value& rhs ) const
+{
+    if( this == &rhs )
+    {
+        return true;
+    }
+
+    if( not Value::operator==( rhs ) )
+    {
+        return false;
+    }
+
+    const auto& other = static_cast< const Specification& >( rhs );
+    return ( this->name() == other.name() );
+}
+
 void Specification::accept( Visitor& visitor )
 {
     visitor.visit( *this );

--- a/src/Specification.h
+++ b/src/Specification.h
@@ -83,6 +83,8 @@ namespace libcasm_ir
 
         std::size_t hash( void ) const override;
 
+        u1 operator==( const Value& rhs ) const override;
+
         void accept( Visitor& visitor ) override;
 
         static inline Value::ID classid( void )

--- a/src/Value.cpp
+++ b/src/Value.cpp
@@ -177,6 +177,11 @@ std::string Value::label( void ) const
     }
 }
 
+u1 Value::operator==( const Value& rhs ) const
+{
+    return ( this->id() == rhs.id() ) and ( this->type() == rhs.type() );
+}
+
 void Value::iterate(
     const Traversal order, std::function< void( Value& ) > action )
 {

--- a/src/Value.h
+++ b/src/Value.h
@@ -224,27 +224,15 @@ namespace libcasm_ir
 
         virtual std::size_t hash( void ) const = 0;
 
-        inline u1 operator==( const Value& rhs ) const
-        {
-            if( this != &rhs )
-            {
-                if( this->id() != rhs.id() or this->hash() != rhs.hash()
-                    or this->type() != rhs.type() )
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+        virtual u1 operator==( const Value& rhs ) const;
 
         inline u1 operator!=( const Value& rhs ) const
         {
             return !operator==( rhs );
         }
 
-        virtual void iterate(
-            const Traversal order, std::function< void( Value& ) > callback )
-            final;
+        virtual void iterate( const Traversal order,
+            std::function< void( Value& ) > callback ) final;
 
         virtual void accept( Visitor& visitor ) = 0;
 
@@ -324,6 +312,37 @@ namespace libcasm_ir
             }
 
             return h;
+        }
+
+        u1 operator==( const Value& rhs ) const override final
+        {
+            if( this == &rhs )
+            {
+                return true;
+            }
+
+            if( not Value::operator==( rhs ) )
+            {
+                return false;
+            }
+
+            const auto& other = static_cast< const ValueList& >( rhs );
+            if( this->size() != other.size() )
+            {
+                return false;
+            }
+
+            const auto end = this->end();
+            for( auto it1 = this->begin(), it2 = other.begin(); it1 != end;
+                 ++it1, ++it2 )
+            {
+                if( **it1 != **it2 )
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         void accept( Visitor& visitor ) override final


### PR DESCRIPTION
Using the hash code to compare two objects is wrong (e.g. hash collisions).