### PR TITLE
Fix build with clang 5.0

### DIFF
--- a/src/Visitor.h
+++ b/src/Visitor.h
@@ -44,6 +44,8 @@
 
 #include <libcasm-ir/CasmIR>
 
+#include <functional>
+
 namespace libcasm_ir
 {
     class Specification;


### PR DESCRIPTION
Include for `std::function` was missing