### PR TITLE
Annotation: Don't pass relation type as shared_ptr in valid()

### DIFF
--- a/src/Annotation.cpp
+++ b/src/Annotation.cpp
@@ -199,12 +199,12 @@ Type::ID Annotation::inference( const std::vector< Type::Ptr >& argumentTypes,
     }
 }
 
-u1 Annotation::valid( const RelationType::Ptr& type ) const
+u1 Annotation::valid( const RelationType& type ) const
 {
-    const auto resultTypeKind = type->result().kind();
+    const auto resultTypeKind = type.result().kind();
     std::vector< Type::Kind > key = { resultTypeKind };
 
-    const auto& argumentTypes = type->arguments();
+    const auto& argumentTypes = type.arguments();
     for( std::size_t i = 0; i < argumentTypes.size(); i++ )
     {
         Type::Kind argumentTypeKind = argumentTypes[ i ]->kind();

--- a/src/Annotation.h
+++ b/src/Annotation.h
@@ -106,7 +106,7 @@ namespace libcasm_ir
         Type::ID inference( const std::vector< Type::Ptr >& argumentTypes,
             const std::vector< Value::Ptr >& values ) const;
 
-        u1 valid( const RelationType::Ptr& type ) const;
+        u1 valid( const RelationType& type ) const;
 
       private:
         Value::ID m_valueId;


### PR DESCRIPTION
`Annotation::valid` only checks if the relation type is valid, but does not store or take over the ownership of it. Thus passing the relation type as const-ref is much better, because:
* No need to handle `nullptrs` (this was missing in the old code!)
* No heap allocation required when client just wants to check a (temporary)  relation. Now the relation can be allocated on the stack instead.